### PR TITLE
Add dump data fields endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,20 +67,8 @@ func main() {
 			fieldDataMap := make(map[string]string)
 			for _, data := range fieldData {
 				parts := strings.Split(data, ": ")
-				keyPart, err := strconv.Unquote(parts[0])
-
-				if err != nil {
-					c.Error(err)
-					return
-				}
-
-				valuePart, err := strconv.Unquote(parts[1])
-
-				if err != nil {
-					c.Error(err)
-					return
-				}
-
+				keyPart := parts[0]
+				valuePart := parts[1]
 				fieldDataMap[keyPart] = valuePart
 			}
 
@@ -101,13 +89,8 @@ func main() {
 			fields = append(fields, field)
 		}
 
-		jsonFields, err := json.Marshal(fields)
-		fmt.Println(string(jsonFields))
-
-		res := []string{"foo", "bar", string(jsonFields)}
-		c.JSON(200, res)
-	},
-	)
+		c.JSON(200, fields)
+	})
 
 	r.POST("/fill-pdf", func(c *gin.Context) {
 		file, err := c.FormFile("file")

--- a/main.go
+++ b/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -11,6 +14,40 @@ func main() {
 	gin.SetMode(gin.ReleaseMode)
 
 	r := gin.Default()
+
+	r.GET("/dump-data-fields", func(c *gin.Context) {
+		file, err := c.FormFile("file")
+
+		if err != nil {
+			println("No file")
+			c.Error(err)
+			return
+		}
+
+		// Create the tempdir and tempfile for pdftk to operate on
+		tempdir := os.TempDir()
+		tempfile := tempdir + "/temp.pdf"
+
+		err = c.SaveUploadedFile(file, tempfile)
+
+		args := []string{
+			tempfile,
+			"dump_data_fields",
+		}
+
+		out, err := exec.Command("pdftk", args...).Output()
+
+		if err != nil {
+			println("pdftk error: " + err.Error())
+		}
+
+		output := string(out[:])
+
+		fields := strings.Split(output, "")
+
+		res := []string{"foo", "bar", string(output)}
+		c.JSON(200, res)
+	})
 
 	r.POST("/fill-pdf", func(c *gin.Context) {
 		file, err := c.FormFile("file")
@@ -44,6 +81,7 @@ func main() {
 
 		c.File(tempfilefilled)
 	})
-
-	r.Run(":80")
+	port := ":9092"
+	fmt.Print("Running on port " + port)
+	r.Run(port)
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -45,7 +44,8 @@ func main() {
 		out, err := exec.Command("pdftk", args...).Output()
 
 		if err != nil {
-			println("pdftk error: " + err.Error())
+			c.Error(err)
+			return
 		}
 
 		output := string(out[:])
@@ -57,8 +57,6 @@ func main() {
 
 		var fields []Field
 		for _, pdftkField := range pdftkFields[1:] {
-			fmt.Println("This is the field")
-			fmt.Println(pdftkField)
 			fieldData := strings.Split(pdftkField, "\n")
 
 			// Remove the empty string at the end of the field data list
@@ -124,7 +122,5 @@ func main() {
 
 		c.File(tempfilefilled)
 	})
-	port := ":9092"
-	fmt.Print("Running on port " + port)
-	r.Run(port)
+	r.Run(":80")
 }

--- a/main.go
+++ b/main.go
@@ -5,10 +5,18 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 )
+
+type Field struct {
+	FieldType          string
+	FieldName          string
+	FieldFlags         float64
+	FieldJustification string
+}
 
 func main() {
 	gin.SetMode(gin.ReleaseMode)
@@ -19,7 +27,6 @@ func main() {
 		file, err := c.FormFile("file")
 
 		if err != nil {
-			println("No file")
 			c.Error(err)
 			return
 		}
@@ -43,11 +50,59 @@ func main() {
 
 		output := string(out[:])
 
-		fields := strings.Split(output, "")
+		pdftkFields := strings.Split(output, "---\n")
 
-		res := []string{"foo", "bar", string(output)}
+		// Remove the empty string from the start of the fields list
+		_, pdftkFields = pdftkFields[0], pdftkFields[1:]
+
+		var fields []Field
+		for _, pdftkField := range pdftkFields[1:] {
+			fmt.Println("This is the field")
+			fmt.Println(pdftkField)
+			fieldData := strings.Split(pdftkField, "\n")
+
+			// Remove the empty string at the end of the field data list
+			fieldData = fieldData[:len(fieldData)-1]
+
+			fieldDataMap := make(map[string]string)
+			for _, data := range fieldData {
+				parts := strings.Split(data, ": ")
+				fmt.Println(strings.Join(parts, "--------"))
+				fmt.Println(parts[0])
+				fmt.Println(parts[1])
+				fieldDataMap[parts[0]] = parts[1]
+			}
+
+			// fmt.Println("This is the field after split")
+			// fmt.Println(fieldData)
+			// fieldType := fieldData[0]
+			// fieldName := fieldData[1]
+			fieldFlags, err := strconv.ParseFloat(fieldDataMap["FieldFlags"], 64)
+
+			if err != nil {
+				c.Error(err)
+				return
+			}
+
+			// fieldJustification := fieldData[3]
+
+			field := Field{
+				FieldType:          fieldDataMap["FieldType"],
+				FieldName:          fieldDataMap["FieldName"],
+				FieldFlags:         fieldFlags,
+				FieldJustification: fieldDataMap["FieldJustification"],
+			}
+
+			fields = append(fields, field)
+		}
+
+		jsonFields, err := json.Marshal(fields)
+		fmt.Println(string(jsonFields))
+
+		res := []string{"foo", "bar", string(jsonFields)}
 		c.JSON(200, res)
-	})
+	},
+	)
 
 	r.POST("/fill-pdf", func(c *gin.Context) {
 		file, err := c.FormFile("file")

--- a/main.go
+++ b/main.go
@@ -122,5 +122,6 @@ func main() {
 
 		c.File(tempfilefilled)
 	})
+
 	r.Run(":80")
 }

--- a/main.go
+++ b/main.go
@@ -67,24 +67,29 @@ func main() {
 			fieldDataMap := make(map[string]string)
 			for _, data := range fieldData {
 				parts := strings.Split(data, ": ")
-				fmt.Println(strings.Join(parts, "--------"))
-				fmt.Println(parts[0])
-				fmt.Println(parts[1])
-				fieldDataMap[parts[0]] = parts[1]
+				keyPart, err := strconv.Unquote(parts[0])
+
+				if err != nil {
+					c.Error(err)
+					return
+				}
+
+				valuePart, err := strconv.Unquote(parts[1])
+
+				if err != nil {
+					c.Error(err)
+					return
+				}
+
+				fieldDataMap[keyPart] = valuePart
 			}
 
-			// fmt.Println("This is the field after split")
-			// fmt.Println(fieldData)
-			// fieldType := fieldData[0]
-			// fieldName := fieldData[1]
 			fieldFlags, err := strconv.ParseFloat(fieldDataMap["FieldFlags"], 64)
 
 			if err != nil {
 				c.Error(err)
 				return
 			}
-
-			// fieldJustification := fieldData[3]
 
 			field := Field{
 				FieldType:          fieldDataMap["FieldType"],

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 		_, pdftkFields = pdftkFields[0], pdftkFields[1:]
 
 		var fields []Field
-		for _, pdftkField := range pdftkFields[1:] {
+		for _, pdftkField := range pdftkFields[0:] {
 			fieldData := strings.Split(pdftkField, "\n")
 
 			// Remove the empty string at the end of the field data list


### PR DESCRIPTION
This PR exposes a `dump-data-fields` endpoint. After passing a file to the endpoint (in the same manner as you provide a file to the `fill-pdf` endpoint), a JSON list of objects containing information for each field will be returned.

Example output:

```
[
    {
        "FieldType": "Text",
        "FieldName": "Address",
        "FieldFlags": 4096,
        "FieldJustification": "Left"
    },
    {
        "FieldType": "Text",
        "FieldName": "Date",
        "FieldFlags": 0,
        "FieldJustification": "Left"
    }
]
```

@KatSick This is my first bit of go code, please don't hesitate to let me know how to improve it!