### PR TITLE
Add flatten option to fill-pdf endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `docker pull katsick/pdftkgolangservice:1.1.0`
 
-## Hot to use
+## How to use
 
 Invoke HTTP request to the service. Example below:
 
@@ -24,6 +24,12 @@ Content-Disposition: form-data; name="json"
 {"field1":"hello","field2":"world"}
 --2
 ```
+
+### Flatten option
+
+By default, the service flattens the PDF file (making a form non-editable). If you do 
+not want the service to flatten the file, provide the query param `flatten=false` to the `fill-pdf`
+endpoint. i.e. `POST /fill-pdf?flatten=false`
 
 ## Development
 

--- a/fillpdf.go
+++ b/fillpdf.go
@@ -15,8 +15,10 @@ import (
 type Form map[string]interface{}
 
 // Fill a PDF form with the specified form values and create a final filled PDF file.
-// One variadic boolean specifies, whenever to overwrite the destination file if it exists.
-func Fill(form Form, formPDFFile, destPDFFile string, overwrite ...bool) (err error) {
+// Options: 
+// - overwrite the destination file if it exists
+// - flatten the PDF file (see PDFtk documentation)
+func Fill(form Form, formPDFFile, destPDFFile string, overwrite bool, flatten bool) (err error) {
 	// Get the absolute paths.
 	formPDFFile, err = filepath.Abs(formPDFFile)
 	if err != nil {
@@ -72,8 +74,10 @@ func Fill(form Form, formPDFFile, destPDFFile string, overwrite ...bool) (err er
 		formPDFFile,
 		"fill_form", fdfFile,
 		"output", outputFile,
-		"flatten",
 	}
+	if flatten {
+		args = append(args, "flatten")
+	} 
 
 	// Run the pdftk utility.
 	err = runCommandInPath(tmpDir, "pdftk", args...)
@@ -86,7 +90,7 @@ func Fill(form Form, formPDFFile, destPDFFile string, overwrite ...bool) (err er
 	if err != nil {
 		return fmt.Errorf("failed to check if destination PDF file exists: %v", err)
 	} else if e {
-		if len(overwrite) == 0 || !overwrite[0] {
+		if !overwrite {
 			return fmt.Errorf("destination PDF file already exists: '%s'", destPDFFile)
 		}
 

--- a/main.go
+++ b/main.go
@@ -91,6 +91,13 @@ func main() {
 	})
 
 	r.POST("/fill-pdf", func(c *gin.Context) {
+		flatten_param := c.DefaultQuery("flatten", "true")
+		flatten, err := strconv.ParseBool(flatten_param)
+		if err != nil {
+			c.Error(err)
+			return
+		}
+
 		file, err := c.FormFile("file")
 
 		if err != nil {
@@ -113,7 +120,7 @@ func main() {
 			return
 		}
 
-		err = Fill(dynamic, tempfile, tempfilefilled, true)
+		err = Fill(dynamic, tempfile, tempfilefilled, true, flatten)
 
 		if err != nil {
 			c.Error(err)


### PR DESCRIPTION
I added an option to NOT flatten the PDF when filling it. This allows pre-filling a PDF form using the service, and the users can then continue filling the form manually.